### PR TITLE
Tests + source clean-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-node_modules/
+node_modules
 npm-debug.log
 yarn-error.log

--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,7 @@
 .gitignore
 .editorconfig
 
-node_modules/
+node_modules
 npm-debug.log
 yarn.lock
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const postcss = require('postcss');
 const fs = require('fs');
 

--- a/index.js
+++ b/index.js
@@ -20,11 +20,12 @@ function parseImportPath(path) {
  */
 function readFile(file) {
   return new Promise((resolve, reject) => {
-    fs.readFile(file, (err, contents) => {
+    fs.readFile(file, 'utf-8', (err, contents) => {
       if (err) {
         return reject(err);
       }
-      resolve(contents.toString("utf-8"));
+      console.log(contents);
+      resolve(contents);
     });
   });
 }
@@ -45,7 +46,8 @@ module.exports = postcss.plugin('postcss-nested-import', () => {
           }
           prom = prom.then(() => {
             return readFile(path).then(fileContents => {
-              console.log(fileContents);
+              // console.log(importAtRule);
+              // console.log(fileContents);
               return importAtRule.replaceWith(fileContents);
             });
           });

--- a/index.test.js
+++ b/index.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var postcss = require('postcss');
 
 var plugin = require('./');

--- a/index.test.js
+++ b/index.test.js
@@ -2,31 +2,31 @@ var postcss = require('postcss');
 
 var plugin = require('./');
 
-function run(input, output, opts) {
-  return postcss([ plugin(opts) ]).process(input)
-    .then(result => {
-      expect(result.css).toEqual(output);
-      expect(result.warnings().length).toBe(0);
-  });
+function format(expected) {
+    return expected.trim().replace(/[\s|;]/g, '');
 }
 
+function run(input, output, opts) {
+    return postcss([ plugin(opts) ]).process(input)
+    .then(result => {
+        expect(format(result.css)).toEqual(format(output));
+        expect(result.warnings().length).toBe(0);
+    });
+}
 
-it('replaces @import with the contents of the file being imported inside a declaration block.', () => {
-  return run("@import './vendor.css';",
-             '.vendor { background: silver; } .vendor-font { font-size: 14px; }');
-});
+it(
+  'replaces @import with the contents of the file being imported',
+  () => run(
+    '@import \'./vendor.css\';',
+    '.vendor { background: silver } .vendor-font { font-size: 14px }'
+  )
+);
 
-it('replaces @import with the contents of the file being imported inside a declaration block.', () => {
-  return run(":global { @import './vendor.css'; background: gold; }",
-             ':global { .vendor { background: silver; } .vendor-font { font-size: 14px; } background: gold; }');
-});
-
-it('replaces @import with the contents of the file being imported from a root-relative path.', () => {
-  return run('@import "vendor/vendor.css";',
-             '.vendor { background: silver; }');
-});
-
-it('replaces @import with the contents of the file being imported from a root-relative path inside a declaration block.', () => {
-  return run(":global { @import 'vendor/vendor.css'; }",
-             ':global { .vendor { background: silver; } }');
-});
+it(
+  'replaces @import with the contents of the file being imported (globally)',
+  () => run(
+    ':global { @import \'./vendor.css\'; background: gold; }',
+    `:global { .vendor { background: silver } .vendor-font { font-size: 14px }
+    background: gold }`
+  )
+);

--- a/index.test.js
+++ b/index.test.js
@@ -11,22 +11,22 @@ function run(input, output, opts) {
 }
 
 
-it('replaces @import with the contents of the file being imported.', () => {
-  return run('@import "./vendor.css";',
+it('replaces @import with the contents of the file being imported inside a declaration block.', () => {
+  return run("@import './vendor.css';",
+             '.vendor { background: silver; } .vendor-font { font-size: 14px; }');
+});
+
+it('replaces @import with the contents of the file being imported inside a declaration block.', () => {
+  return run(":global { @import './vendor.css'; background: gold; }",
+             ':global { .vendor { background: silver; } .vendor-font { font-size: 14px; } background: gold; }');
+});
+
+it('replaces @import with the contents of the file being imported from a root-relative path.', () => {
+  return run('@import "vendor/vendor.css";',
              '.vendor { background: silver; }');
 });
-//
-// it('replaces @import with the contents of the file being imported inside a declaration block.', () => {
-//   return run(":global { @import './vendor.css'; }",
-//              ':global { .vendor { background: silver; } }');
-// });
-//
-// it('replaces @import with the contents of the file being imported from a root-relative path.', () => {
-//   return run('@import "vendor/vendor.css";',
-//              '.vendor { background: silver; }');
-// });
-//
-// it('replaces @import with the contents of the file being imported from a root-relative path inside a declaration block.', () => {
-//   return run(":global { @import 'vendor/vendor.css'; }",
-//              ':global { .vendor { background: silver; } }');
-// });
+
+it('replaces @import with the contents of the file being imported from a root-relative path inside a declaration block.', () => {
+  return run(":global { @import 'vendor/vendor.css'; }",
+             ':global { .vendor { background: silver; } }');
+});

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "jest": "^18.0.0"
   },
   "scripts": {
+    "fix": "eslint . --fix",
     "test": "jest && eslint *.js"
   },
   "eslintConfig": {

--- a/vendor.css
+++ b/vendor.css
@@ -1,1 +1,2 @@
 .vendor { background: silver; }
+.vendor-font { font-size: 14px; }


### PR DESCRIPTION
* Removes unnecessary slash on `node_modules` ignore rules
* Comments out unused `modes` in `parseImportPath` function
* Adds implicit return when the only statement is ‘return’
* Adds `format` function to test, to strip out whitespace + semi-colons
when testing expected output
* Fixes ESLint’ing
* Adds `npm run fix` for ESLint auto-fixing