### PR TITLE
emit dependency message anouncing dependency to imported file

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const resolve = require("resolve");
 module.exports = () => {
   return {
     AtRule: {
-      "nested-import": (node) => {
+      "nested-import": (node, { result }) => {
         if (
           !node.params ||
           typeof node.params !== "string" ||
@@ -42,6 +42,12 @@ module.exports = () => {
           });
 
           replacement = readFileSync(resolvedPath, "utf8");
+          result.messages.push({
+            type: "dependency",
+            plugin: "postcss-nested-import",
+            file: resolvedPath,
+            parent: result.opts.from,
+          });
         } catch (error) {
           throw node.error(`error reading file:\n${id}`);
         }


### PR DESCRIPTION
This enables hot module replacement with supporting build tools (like Vite).

see https://postcss.org/api/#result-messages